### PR TITLE
Adds support for using a json file for POST requests.

### DIFF
--- a/Search-API/request.json
+++ b/Search-API/request.json
@@ -1,0 +1,6 @@
+{
+  "query": "from:TwitterDev",
+  "maxResults": "10",
+  "fromDate": "202101010000",
+  "toDate": "202102010000"
+}


### PR DESCRIPTION
### Problem and solution

Provides an alternative way to use the Search script by supporting a json request file instead of having to pass all arguments as command line options.

### Result

Modified the search.py script to support a new flag (-r) to point to a newly added request.json file that contains the POST request parameters.