### PR TITLE
User context

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@ ACCOUNT_NAME=""
 POWERTRACK_LABEL=""
 SEARCH_LABEL=""
 
-# Twitter app creds for Engagement APITWITTER_CONSUMER_KEY=""
+# Twitter app creds for Engagement API
 TWITTER_CONSUMER_KEY=""
 TWITTER_CONSUMER_SECRET=""
 TWITTER_ACCESS_TOKEN=""

--- a/Engagement-API/generate_user_access_tokens.py
+++ b/Engagement-API/generate_user_access_tokens.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Twitter, Inc.
+# Licensed under the Apache License, Version 2.0
+# http://www.apache.org/licenses/LICENSE-2.0
+
+# This script generates a user's access tokens which can be used to make requests on behalf of the user, also known as OAuth 1.0a (user context) authentication method
+# Docs: https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
+
+import os
+import sys
+import requests
+from requests_oauthlib import OAuth1Session
+from dotenv import load_dotenv
+load_dotenv(verbose=True)  # Throws error if it can't find .env file
+
+# Retrieves and stores credential information from the '.env' file
+CONSUMER_KEY = os.getenv("TWITTER_CONSUMER_KEY")
+CONSUMER_SECRET = os.getenv("TWITTER_CONSUMER_SECRET")
+ACCESS_TOKEN = os.getenv("TWITTER_ACCESS_TOKEN")
+TOKEN_SECRET = os.getenv("TWITTER_ACCESS_TOKEN_SECRET")
+
+# Request an OAuth Request Token. This is the first step of the 3-legged OAuth flow. This generates a token that you can use to request user authorization for access.
+def request_token():
+
+    oauth = OAuth1Session(CONSUMER_KEY, client_secret=CONSUMER_SECRET, callback_uri='oob')
+
+    url = "https://api.twitter.com/oauth/request_token"
+
+    try:
+        response = oauth.fetch_request_token(url)
+        resource_owner_oauth_token = response.get('oauth_token')
+        resource_owner_oauth_token_secret = response.get('oauth_token_secret')
+    except requests.exceptions.RequestException as e:
+            print(e)
+            sys.exit(120)
+    
+    return resource_owner_oauth_token, resource_owner_oauth_token_secret
+
+# Use the OAuth Request Token received in the previous step to redirect the user to authorize your developer App for access.
+def get_user_authorization(resource_owner_oauth_token):
+
+    authorization_url = f"https://api.twitter.com/oauth/authorize?oauth_token={resource_owner_oauth_token}"
+    authorization_pin = input(f"Copy and past the following URL in your web browser to grant access to this application: {authorization_url} \n Paste PIN here: ")
+
+    return(authorization_pin)
+
+# Exchange the OAuth Request Token you obtained previously for the user’s Access Tokens.
+def get_user_access_tokens(resource_owner_oauth_token, resource_owner_oauth_token_secret, authorization_pin):
+
+    oauth = OAuth1Session(CONSUMER_KEY, 
+                            client_secret=CONSUMER_SECRET, 
+                            resource_owner_key=resource_owner_oauth_token, 
+                            resource_owner_secret=resource_owner_oauth_token_secret, 
+                            verifier=authorization_pin)
+    
+    url = "https://api.twitter.com/oauth/access_token"
+
+    try: 
+        response = oauth.fetch_access_token(url)
+        access_token = response['oauth_token']
+        access_token_secret = response['oauth_token_secret']
+        user_id = response['user_id']
+        screen_name = response['screen_name']
+    except requests.exceptions.RequestException as e:
+            print(e)
+            sys.exit(120)
+
+    print(access_token, access_token_secret, user_id, screen_name)
+    return(access_token, access_token_secret, user_id, screen_name)
+
+if __name__ == '__main__':
+    resource_owner_oauth_token, resource_owner_oauth_token_secret = request_token()
+    authorization_pin = get_user_authorization(resource_owner_oauth_token)
+    access_token, access_token_secret, user_id, screen_name = get_user_access_tokens(resource_owner_oauth_token, resource_owner_oauth_token_secret, authorization_pin)
+    
+    

--- a/Engagement-API/generate_user_access_tokens.py
+++ b/Engagement-API/generate_user_access_tokens.py
@@ -6,18 +6,16 @@
 # This script generates a user's access tokens which can be used to make requests on behalf of the user, also known as OAuth 1.0a (user context) authentication method
 # Docs: https://developer.twitter.com/en/docs/authentication/oauth-1-0a/obtaining-user-access-tokens
 
-import os
 import sys
 import requests
 from requests_oauthlib import OAuth1Session
-from dotenv import load_dotenv
-load_dotenv(verbose=True)  # Throws error if it can't find .env file
 
-# Retrieves and stores credential information from the '.env' file
-CONSUMER_KEY = os.getenv("TWITTER_CONSUMER_KEY")
-CONSUMER_SECRET = os.getenv("TWITTER_CONSUMER_SECRET")
-ACCESS_TOKEN = os.getenv("TWITTER_ACCESS_TOKEN")
-TOKEN_SECRET = os.getenv("TWITTER_ACCESS_TOKEN_SECRET")
+#Prompt developer to enter App credentials
+print("Enter the credentials for your developer App below.")
+CONSUMER_KEY = input("Consumer key: ")
+CONSUMER_SECRET = input("Consumer secret: ")
+ACCESS_TOKEN = input("Access token: ")
+TOKEN_SECRET = input("Access token secret: ")
 
 # Request an OAuth Request Token. This is the first step of the 3-legged OAuth flow. This generates a token that you can use to request user authorization for access.
 def request_token():
@@ -40,7 +38,7 @@ def request_token():
 def get_user_authorization(resource_owner_oauth_token):
 
     authorization_url = f"https://api.twitter.com/oauth/authorize?oauth_token={resource_owner_oauth_token}"
-    authorization_pin = input(f"Copy and past the following URL in your web browser to grant access to this application: {authorization_url} \n Paste PIN here: ")
+    authorization_pin = input(f" \n Send the following URL to the user you want to generate access tokens for. \n → {authorization_url} \n This URL will allow the user to authorize your application and generate a PIN. \n Paste PIN here: ")
 
     return(authorization_pin)
 
@@ -65,12 +63,11 @@ def get_user_access_tokens(resource_owner_oauth_token, resource_owner_oauth_toke
             print(e)
             sys.exit(120)
 
-    print(access_token, access_token_secret, user_id, screen_name)
     return(access_token, access_token_secret, user_id, screen_name)
 
 if __name__ == '__main__':
     resource_owner_oauth_token, resource_owner_oauth_token_secret = request_token()
     authorization_pin = get_user_authorization(resource_owner_oauth_token)
     access_token, access_token_secret, user_id, screen_name = get_user_access_tokens(resource_owner_oauth_token, resource_owner_oauth_token_secret, authorization_pin)
-    
+    print(f"\n User @handle: {screen_name}", f"\n User ID: {user_id}", f"\n User access token: {access_token}", f" \n User access token secret: {access_token_secret} \n")
     

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Sample Python code that makes it easy to get started with the Twitter Enterprise
 - The `search.py` script supports both 'data' and 'counts' (`-c`) requests as well as auto pagination (`-n` flag)
 - The PowerTrack `get_stream.py` script supports a custom chunksize (`-c` flag) – useful when testing low volume streams
 - Generate a bearer token for use with the /totals endpoint of the Engagement API (`/Engagement-API/generate_bearer_token.py`)
+- Generate user access tokens to authorize requests to the Engagement API and access user-owned private  metrics (`/Engagement-API/generate_user_access_tokens.py`)
 - Supports pretty printing the results either by default or through an optional flag (`-p`)
 
 ## Dependencies
@@ -49,7 +50,25 @@ TWITTER_ACCESS_TOKEN_SECRET=""
 TWITTER_BEARER_TOKEN=""
 ```
 
-Note: The Engagement-API/generate_bearer_token.py script can be used to generate a bearer token. You can then store that returned value in the '.env' file as shown above.
+### Authenticating with the Engagement API 
+
+Two authentication methods are available with the Engagement API: [OAuth 1.0a](https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth1.0a) and [OAuth 2.0 Bearer Token](https://developer.twitter.com/en/docs/tutorials/authenticating-with-twitter-api-for-enterprise/authentication-method-overview#oauth2.0).
+
+**OAuth 2.0 Bearer Token** allows you to access publicly available engagement metrics. This authentication method can be used to get total counts for Favorites (aka Likes), Retweets, Quote Tweets, Replies, and video views for any publicly available Tweets when making requests to the /totals endpoint. 
+
+→ Use the `/Engagement-API/generate_bearer_token.py` script to generate the required bearer token. You can then store that returned value in the '.env' file as shown above.
+
+**OAuth 1.0a** allows you to make requests on behalf of a user and access private engagement metrics that are owned by the user in question. 
+
+This authentication method is required for:
+* All requests sent to the /28hr endpoint and /historical endpoint
+* Accessing any of the following private metrics: Impressions, Engagements, Media Views, Media Engagements, URL Clicks, Hashtag Clicks, Detail Expands, Permalink Clicks, App Install Attempts, App Opens, Email Tweet, User Follows, and User Profile Clicks
+
+→ Use the `/Engagement-API/generate_user_access_tokens.py` script to get a user to authorize your application and generate the required Access Tokens (user's access token and access token secret). You can then store the returned Access Tokens, along with your developer App's consumer key and secret in the '.env' file as shown above.
+
+Note: If you are sending a request on behalf of your own Twitter account (in other words, the account that owns your developer App), you can generate the required Access Tokens directly from within the [developer portal](https://developer.twitter.com/en/portal/projects-and-apps).
+
+[Find out more](https://developer.twitter.com/en/docs/twitter-api/enterprise/engagement-api/guides/authenticating-with-the-engagement-api) about authenticating with the Engagement API.
 
 ## Engagement API
 Pass one or more Tweet IDs to get a variety of impression and engagement metrics.


### PR DESCRIPTION
### Problem

Accessing private metrics with the Engagement API requires user authentication. This repo didn't demonstrate how to use the 3-legged OAuth flow to enable a user to authorize the developer application and generate the required Access Tokens to make requests on behalf of the user in question.

### Solution

* Created script `/Engagement-API/generate_user_access_tokens.py` to allow developers to generate user Access Tokens using the 3-legged OAuth flow.
* Added instructions  in the `README.md` file to explain how authentication works with the Engagement API and how to use the Access Tokens.
* I also fixed a typo in the `.env.example` file (unrelated to the problem described above).

### Steps to test & review

1. Read new instructions in `README.md` to ensure they make sense and can be followed.
2. Use `/Engagement-API/generate_user_access_tokens.py` to generate Access Tokens for another Twitter account (e.g. a test account).
3. Use the Access Tokens obtained in the previous step to populate `.env` file and make a request to the Engagement API to obtain private metrics on behalf of the account used in step 2.
